### PR TITLE
Follow-up for #91

### DIFF
--- a/MiscVBAFunctions/Modules/Test__MiscArray.bas
+++ b/MiscVBAFunctions/Modules/Test__MiscArray.bas
@@ -297,7 +297,7 @@ Private Sub Test_ArrayToNewTable_1dArray()
     Arr(2) = "col3"
     
     Set RangeObj = WB.ActiveSheet.Range("K4")
-    Set LO = ArrayToNewTable("TestTable2", Arr, RangeObj, True)
+    Set LO = ArrayToNewTable("TestTable2", Ensure2dArray(Arr), RangeObj, True)
     
     'Assert:
     Assert.AreEqual "TestTable2", LO.Name


### PR DESCRIPTION
- Let the caller of `ArrayToRange` or `ArrayToNewTable` use `Ensure2dArray` if necessary. Don't call it inside `ArrayToRange`.
- Fix unit tests.
- Improve doc strings.