### PR TITLE
Avoid date strings auto-correction to dates in Excel

### DIFF
--- a/MiscVBAFunctions/Modules/MiscArray.bas
+++ b/MiscVBAFunctions/Modules/MiscArray.bas
@@ -69,7 +69,7 @@ Public Function ArrayToRange( _
                         
                     End If
                     If IsNumeric(Data(CountOuter, CountInner)) Then
-                        If Application.WorksheetFunction.IsText(Data(CountOuter, CountInner)) Then
+                        If VarType(Data(CountOuter, CountInner)) = VbString Then
                             Data(CountOuter, CountInner) = "'" & Data(CountOuter, CountInner)
                         End If
                     End If

--- a/MiscVBAFunctions/Modules/MiscArray.bas
+++ b/MiscVBAFunctions/Modules/MiscArray.bas
@@ -78,6 +78,18 @@ Public Function ArrayToRange( _
         Next
     End If
     
+    ' Check for string dates and keep them as strings:
+    For CountOuter = LBound(Data) To UBound(Data)
+        For CountInner = LBound(Data, 2) To UBound(Data, 2)
+            If IsDate(Data(CountOuter, CountInner)) Then ' this would return true, even for strings that looks like dates
+                If VarType(Data(CountOuter, CountInner)) = VbString Then ' This would be false for strings that looks like dates
+                    ' escape strings looking like dates
+                    Data(CountOuter, CountInner) = "'" & Data(CountOuter, CountInner)
+                End If
+            End If
+        Next CountInner
+    Next CountOuter
+    
     CellRange.Value = Data
     Set ArrayToRange = CellRange
 

--- a/MiscVBAFunctions/Modules/Test__Helper_MiscArray.bas
+++ b/MiscVBAFunctions/Modules/Test__Helper_MiscArray.bas
@@ -76,3 +76,28 @@ TestFail:
         Exit Function
     End If
 End Function
+
+
+Function Test_ArrayToNewTable_StringDates(RangeObj As Range)
+
+    Dim Arr() As Variant
+    ReDim Arr(4, 0)
+    
+    Arr(0, 0) = "Dates" ' a string that looks like a date - should remain a string
+    Arr(1, 0) = "2023-12-31" ' a string that looks like a date - should remain a string
+    Arr(2, 0) = "2023/12/31" ' a string that looks like a date - should remain a string
+    Arr(3, 0) = "31 Dec 2023" ' a string that looks like a date - should remain a string
+    Arr(4, 0) = DateSerial(2023, 12, 31) ' an actual date
+    
+    Dim NewTable As ListObject
+    Set NewTable = ArrayToNewTable("TestStringDates", Arr, RangeObj)
+    
+    Dim Pass As Boolean
+    
+    Pass = NewTable.ListColumns("Dates").DataBodyRange(1, 1).Value = "2023-12-31"
+    Pass = NewTable.ListColumns("Dates").DataBodyRange(2, 1).Value = "2023/12/31" And Pass
+    Pass = NewTable.ListColumns("Dates").DataBodyRange(3, 1).Value = "31 Dec 2023" And Pass
+    Pass = NewTable.ListColumns("Dates").DataBodyRange(4, 1).Value = DateSerial(2023, 12, 31) And Pass
+    
+    Test_ArrayToNewTable_StringDates = Pass
+End Function

--- a/tests/testMiscArray.py
+++ b/tests/testMiscArray.py
@@ -142,6 +142,15 @@ class MiscArray(unittest.TestCase):
                     table.range.value,
                 )
 
+            with self.subTest("StringDates"):
+                func = book.macro("Test__Helper_MiscArray.Test_ArrayToNewTable_StringDates")
+
+                range_obj = book.sheets["Sheet1"].range("B1000")
+                
+                self.assertTrue(
+                    func(range_obj)
+                )
+
             with self.subTest("ArrayToNewTable_FunkyHeaders"):
 
                 func_ArrayToNewTable = book.macro("MiscArray.ArrayToNewTable")


### PR DESCRIPTION
Avoid Excel's auto-conversion of date-like strings to dates.

@BartJan142 note there was one failing test before adding this where we check for paths on an E:\ drive. See https://github.com/VirtualActuary/MiscVBAFunctions/issues/126.

@rudolfbyker I tried to add a python test, but not sure if actually runs? Before and after it ran 36 tests. Is this because I added this as a sub-test?

```
PS C:\aa\MiscVBAFunctions\tests> python -m unittest
................F...................
======================================================================
FAIL: test_1 (testMiscFso.TestDictsToTable)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\aa\MiscVBAFunctions\tests\testMiscFso.py", line 16, in test_1
    self.assertTrue(
AssertionError: False is not true

----------------------------------------------------------------------
Ran 36 tests in 43.026s

FAILED (failures=1)
```