### PR TITLE
Feature: Allow specifying explicit number formats per column in `ArrayToRange` and `ArrayToNewTable`

### DIFF
--- a/MiscVBAFunctions/Modules/MiscArray.bas
+++ b/MiscVBAFunctions/Modules/MiscArray.bas
@@ -127,7 +127,8 @@ Public Function ArrayToNewTable( _
     TableName As String, _
     DataIncludingHeaders() As Variant, _
     StartCell As Range, _
-    Optional EscapeFormulas As Boolean = False _
+    Optional EscapeFormulas As Boolean = False, _
+    Optional NumberFormatPerColumn As Collection = Nothing _
 ) As ListObject
     ' Create a ListObject and populate it with data from `DataIncludingHeaders`.
     '
@@ -146,6 +147,11 @@ Public Function ArrayToNewTable( _
     '         If True, formulas get copied as text. (E.x. "=d" -> "'=d")
     '         If False, the data is copied as is.
     '         If this is False and "=[foo]" gets copied, the function will crash.
+    '     NumberFormatPerColumn:
+    '         A number format for each column, in the same order as the columns in `Data`.
+    '         Collection keys are ignored. If given, the data range of each column will be
+    '         set to the corresponding number format from this collection before the values are
+    '         written to the destination range.
     '
     ' Returns:
     '     The new ListObject.
@@ -159,7 +165,9 @@ Public Function ArrayToNewTable( _
         Data:=DataIncludingHeaders, _
         StartCell:=StartCell, _
         EscapeFormulas:=EscapeFormulas, _
-        IncludesHeader:=True _
+        IncludesHeader:=True, _
+        PreventStringConversion:=(NumberFormatPerColumn Is Nothing), _
+        NumberFormatPerColumn:=NumberFormatPerColumn _
     )
     
     Set ArrayToNewTable = StartCell.Worksheet.ListObjects.Add( _

--- a/MiscVBAFunctions/Modules/MiscArray.bas
+++ b/MiscVBAFunctions/Modules/MiscArray.bas
@@ -7,7 +7,8 @@ Public Function ArrayToRange( _
     Data() As Variant, _
     StartCell As Range, _
     Optional EscapeFormulas As Boolean = False, _
-    Optional IncludesHeader As Boolean = False _
+    Optional IncludesHeader As Boolean = False, _
+    Optional PreventStringConversion As Boolean = True _
 ) As Range
     ' This function copies data from the input array to a Range.
     '
@@ -28,6 +29,14 @@ Public Function ArrayToRange( _
     '     IncludesHeader:
     '         Whether `Data` includes a header. The header will be written with a number format
     '         of `@`, because headers must be strings, especially when creating `ListObject`s.
+    '     PreventStringConversion:
+    '         If True, the number format of cells to which strings will be written are set to
+    '         `@` before writing the data, to prevent the string from being converted to
+    '         something else automatically. This could happen if the string looks like a date
+    '         or a boolean, and is usually undesirable behavior.
+    '         If False, the values are written to the cells without touching the number formats.
+    '         This may be useful when the caller of this function already set the number
+    '         formats of the destination range to something useful.
     '
     ' Returns:
     '     The Range to which the data was written.
@@ -82,14 +91,15 @@ Public Function ArrayToRange( _
         Next
     End If
     
-    ' Preserve data types by formatting some cells BEFORE writing the values.
-    For CountOuter = LBound(Data) To UBound(Data)
-        For CountInner = LBound(Data, 2) To UBound(Data, 2)
-            If VarType(Data(CountOuter, CountInner)) = VbString Then
-                StartCell.Offset(CountOuter, CountInner).NumberFormat = "@"
-            End If
-        Next CountInner
-    Next CountOuter
+    If PreventStringConversion Then
+        For CountOuter = LBound(Data) To UBound(Data)
+            For CountInner = LBound(Data, 2) To UBound(Data, 2)
+                If VarType(Data(CountOuter, CountInner)) = VbString Then
+                    StartCell.Offset(CountOuter, CountInner).NumberFormat = "@"
+                End If
+            Next CountInner
+        Next CountOuter
+    End If
     
     CellRange.Value = Data
     Set ArrayToRange = CellRange

--- a/tests/MiscArray/testArrayToRange.py
+++ b/tests/MiscArray/testArrayToRange.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List, Any
 
 from ..util import TestCaseWithFunctionBook
@@ -81,4 +82,79 @@ class TestArrayToRange(TestCaseWithFunctionBook):
         self.assertEqual(
             data,
             self.book.sheets[0].range((1, 1), (len(data), len(data[0]))).value,
+        )
+
+    def test_number_format_per_column(self) -> None:
+        """
+        Set the number format per column.
+        """
+        number_formats: List[str] = ["0.00", "yyyy/mm/dd", "@", "General"]
+
+        data: List[List[Any]] = [
+            # Header: Should always use `@` (Text) as the number format.
+            ["Number", "Date", "Text", "General"],
+            # Body: Checking to see what different number formats do to the same value.
+            [1] * 4,
+            [1.2] * 4,
+            ["1"] * 4,
+            ["1.2"] * 4,
+            ["foo"] * 4,
+            ["2022/11/02"] * 4,
+            ["TRUE"] * 4,
+            [None] * 4,
+            [""] * 4,
+            ["'"] * 4,
+        ]
+
+        self.array_to_range(
+            data,
+            self.book.sheets["Sheet1"].range("A1"),
+            False,  # Don't escape formulas.
+            True,  # The data includes a header.
+            True,  # Don't prevent string conversion.
+            self.book.macro("col")(*number_formats),
+        )
+
+        rng = self.book.sheets[0].range((1, 1), (len(data), len(data[0])))
+
+        # The number formats affect how the data is returned, so the values here won't be exactly the same as what we
+        # put in.
+        self.assertEqual(
+            [
+                ["Number", "Date", "Text", "General"],
+                [1, datetime(1899, 12, 31), 1, 1],
+                [1.2, datetime(1899, 12, 31, 4, 48), 1.2, 1.2],
+                [1, datetime(1899, 12, 31), "1", 1],
+                [1.2, datetime(1899, 12, 31, 4, 48), "1.2", 1.2],
+                ["foo", "foo", "foo", "foo"],
+                [
+                    44867,
+                    datetime(2022, 11, 2),
+                    "2022/11/02",
+                    datetime(2022, 11, 2),
+                ],
+                [True, True, "TRUE", True],
+                [None, None, None, None],
+                [None, None, None, None],
+                [None, None, None, None],
+            ],
+            rng.value,
+        )
+
+        # The number formats should be applied to the cells in the data range, but not the header.
+        self.assertEqual(
+            [
+                ["@", "@", "@", "@"],  # Header
+                ["0.00", "yyyy/mm/dd", "@", "General"],
+                ["0.00", "yyyy/mm/dd", "@", "General"],
+                ["0.00", "yyyy/mm/dd", "@", "General"],
+                ["0.00", "yyyy/mm/dd", "@", "General"],
+                ["0.00", "yyyy/mm/dd", "@", "General"],
+                ["0.00", "yyyy/mm/dd", "@", "yyyy/mm/dd"],  # Oh Excel, why???
+                ["0.00", "yyyy/mm/dd", "@", "General"],
+                ["0.00", "yyyy/mm/dd", "@", "General"],
+                ["0.00", "yyyy/mm/dd", "@", "General"],
+                ["0.00", "yyyy/mm/dd", "@", "General"],
+            ],
+            [[cell.number_format for cell in row] for row in rng.rows],
         )

--- a/tests/MiscArray/testArrayToRange.py
+++ b/tests/MiscArray/testArrayToRange.py
@@ -74,8 +74,9 @@ class TestArrayToRange(TestCaseWithFunctionBook):
         self.array_to_range(
             data,
             self.book.sheets["Sheet1"].range("A1"),
-            False,  # Escape formulas.
+            False,  # Don't escape formulas.
             False,  # No header.
+            True,  # Prevent string conversion.
         )
         self.assertEqual(
             data,


### PR DESCRIPTION
Required to solve this TODO: https://github.com/AutoActuary/autory/blob/aef500c12f05f21ac88f639cea3e0d5612fc2e0a/py/src/autory_py/udfs.py#L350